### PR TITLE
Allow use of slot for imageComponent

### DIFF
--- a/src/Gallery.svelte
+++ b/src/Gallery.svelte
@@ -65,7 +65,9 @@
         class="image"
         style={imgStyle({ scaledHeight, scaledWidth, isLastInRow, isLastRow })}
       >
-        <svelte:component this={imageComponent} {...image} />
+        <slot {index} {image}>
+          <svelte:component this={imageComponent} {...image} />
+        </slot>
       </div>
     {/each}
   </div>


### PR DESCRIPTION
I wanted to use this package with PhotoSwipe, similar to https://fergaldoyle.github.io/image-masonry/svelte-advanced.html

I was able to get most of what I needed by using the `imageComponent` prop except for the `on:click` handler.
This PR makes it possible to use a slot instead. It's not a breaking change because the current `<svelte:component ...` is set as the default slot contents.